### PR TITLE
Configure not create 'javascript', 'helper', 'test'

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -11,5 +11,11 @@ module ChatSpace
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
+
+    config.generators do |g|
+      g.javascripts false
+      g.helper false
+      g.test_framework false
+    end
   end
 end


### PR DESCRIPTION
# WHAT
不要ファイル（javascript, helper, test）をgeneratorで生成しないよう設定する。

# WHY
アプリに不必要なファイルを生成させないため。